### PR TITLE
DB: Normalize airline - move name from flight table to new airline table

### DIFF
--- a/DB/createTables.sql
+++ b/DB/createTables.sql
@@ -38,10 +38,16 @@ CREATE TABLE Airport(
     FOREIGN KEY(city) REFERENCES City(cityId)
 );
 
+CREATE TABLE Airline(
+    airlineCode varchar(3) primary key,  -- 3 letter ICAO code
+	airlineName varchar(100) NOT NULL
+);
+
 CREATE TABLE Flight(
 	flightId varchar(100) primary key,
 	flightName varchar(100) NOT NULL,
-	airlineName varchar(100) NOT NULL
+    airlineCode varchar(3) NOT NULL,
+    FOREIGN KEY(airlineCode) REFERENCES Airline(airlineCode)
 );
 
 CREATE TABLE Schedules(

--- a/DB/drop.sql
+++ b/DB/drop.sql
@@ -4,6 +4,7 @@ DROP TABLE AdminLoginCredentials;
 DROP TABLE Booking;
 DROP TABLE Schedules;
 DROP TABLE Flight;
+DROP TABLE Airline;
 DROP TABLE Users;
 DROP SEQUENCE user_id;
 DROP TABLE Airport;

--- a/DB/loadData.sql
+++ b/DB/loadData.sql
@@ -841,19 +841,31 @@ INSERT INTO Airport (airportId, airportName, city) VALUES ('TISX','Henry E. Rohl
 COMMIT WORK;
 
 
+-- Load Airline Table
+
+INSERT INTO Airline (airlineCode, airlineName) VALUES ('AAL','American Airlines');
+INSERT INTO Airline (airlineCode, airlineName) VALUES ('ASA','Alaska Airlines');
+INSERT INTO Airline (airlineCode, airlineName) VALUES ('DAL','Delta Air Lines');
+INSERT INTO Airline (airlineCode, airlineName) VALUES ('FFT','Frontier Airlines');
+INSERT INTO Airline (airlineCode, airlineName) VALUES ('JBU','JetBlue');
+INSERT INTO Airline (airlineCode, airlineName) VALUES ('UAL','United Airlines');
+INSERT INTO Airline (airlineCode, airlineName) VALUES ('SWA','Southwest Airlines');
+COMMIT WORK;
+
+
 -- Load Flight Table
 
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('UAL1039','United 1039','United Airlines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('SWA1021','Southwest 1021','Southwest Airlines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('JBU1374','JetBlue 1374','JetBlue');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('ASA1137','Alaska Airlines 1137','Alaska Airlines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('AAL1003','American Airlines 1003','American Airlines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('DAL1032','Delta 1032','Delta Air Lines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('FFT1511','Frontier 1511','Frontier Airlines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('FFT1513','Frontier 1513','Frontier Airlines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('JBU1258','JetBlue 1258','JetBlue');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('AAL1138','American Airlines 1138','American Airlines');
-INSERT INTO Flight (flightId, flightName, airlineName) VALUES ('DAL1085','Delta 1085','Delta Air Lines');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('UAL1039','United 1039','UAL');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('SWA1021','Southwest 1021','SWA');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('JBU1374','JetBlue 1374','JBU');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('ASA1137','Alaska Airlines 1137','ASA');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('AAL1003','American Airlines 1003','AAL');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('DAL1032','Delta 1032','DAL');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('FFT1511','Frontier 1511','FFT');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('FFT1513','Frontier 1513','FFT');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('JBU1258','JetBlue 1258','JBU');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('AAL1138','American Airlines 1138','AAL');
+INSERT INTO Flight (flightId, flightName, airlineCode) VALUES ('DAL1085','Delta 1085','DAL');
 COMMIT WORK;
 
 


### PR DESCRIPTION
Sorry guys, I know this is a breaking change, but I think we technically have a normalization issue here.  `airlineName` looks like a property of `Flight`, which seems wrong.  I moved `airlineName` to a new `airline` table instead.

I am using `airlineCode` (e.g. AAL for American) as a natural/primary key instead of using an autogenerated ID.